### PR TITLE
Make Error type non-exhaustive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// An error
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// The CHS address requested cannot be represented in CHS
     ///


### PR DESCRIPTION
We might want to add more variants later.

This is a breaking change.

xref https://github.com/rust-disk-partition-management/gptman/pull/78