### PR TITLE
Add `InvalidSignature` and `InvalidBootFlag` error variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ include = ["src/**/*.rs", "tests/fixtures/*.img", "README.md", "LICENSE.Apache-2
 bitvec = "0.22"
 bincode = "1.0.1"
 serde = { version = "1.0.116", features = ["derive"] }
+serde-big-array = "0.4.1"
 thiserror = "1.0.24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1388,6 +1388,11 @@ impl MBRPartitionEntry {
             || self.sys == 0xc5
             || self.sys == 0xd5
     }
+
+    /// Returns `true` if the partition is marked active (bootable)
+    pub fn is_active(&self) -> bool {
+        self.boot == BOOT_ACTIVE
+    }
 }
 
 /// An abstraction struct for a logical partition
@@ -1732,6 +1737,10 @@ mod tests {
         assert!(mbr.header.partition_2.is_used());
         assert!(mbr.header.partition_3.is_unused());
         assert!(mbr.header.partition_4.is_unused());
+        assert!(mbr.header.partition_1.is_active());
+        assert!(!mbr.header.partition_2.is_active());
+        assert!(!mbr.header.partition_3.is_active());
+        assert!(!mbr.header.partition_4.is_active());
         assert_eq!(mbr.len(), 4);
         assert_eq!(mbr.header.iter().count(), 4);
         assert_eq!(mbr.header.iter_mut().count(), 4);
@@ -1753,6 +1762,10 @@ mod tests {
         assert!(mbr.header.partition_2.is_used());
         assert!(mbr.header.partition_3.is_unused());
         assert!(mbr.header.partition_4.is_unused());
+        assert!(!mbr.header.partition_1.is_active());
+        assert!(!mbr.header.partition_2.is_active());
+        assert!(!mbr.header.partition_3.is_active());
+        assert!(!mbr.header.partition_4.is_active());
         assert_eq!(mbr.header.partition_2.sys, 0x05);
         assert_eq!(mbr.header.partition_2.starting_lba, 5);
         assert_eq!(mbr.header.partition_2.first_chs, CHS::new(0, 1, 3));


### PR DESCRIPTION
It's useful to let the caller distinguish between a missing MBR (with invalid signature bytes) and a corrupt one.  However, we check the signature inside a deserialize `Visitor`, from which we can only return error strings.

Remove all serialize/deserialize wrappers from the API: `BootstrapCode440` and `BootstrapCode446`, `Signature55AA`, and the boolean boot flag field.  Replace them with bytes or byte arrays, and validate those during `read_from()` and `write_into()`, returning distinct error variants for problems we find.  For convenience, also add an `is_active()` method on `MBRPartitionEntry`.  Add some `Eq` derives that are unblocked by the other changes.

This is a breaking change.