### PR TITLE
(cargo-release) version 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbrman"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Cecile Tonglet <cecile.tonglet@cecton.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Proposed release notes:

* **[BREAKING]** Convert `MBRPartitionEntry.boot` to a `u8`; export `BOOT_INACTIVE` and `BOOT_ACTIVE` constants
* **[BREAKING]** Replace `BootstrapCode440`, `BootstrapCode446`, and `Signature55AA` with `u8` arrays
* **[BREAKING]** Make `Error` type non-exhaustive (#15)
* Add `InvalidSignature` and `InvalidBootFlag` error variants (#18)
* Add `MBRPartitionEntry.is_active()` convenience method
* Zero-fill unused EBR partition entries when writing (#20)
* Add `Eq` derives on structs
* Document 1.51 MSRV