### PR TITLE
Fix `MBR::read_from()` doc comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,8 +393,7 @@ impl MBR {
         })
     }
 
-    /// Read the MBR on a reader. This function will try to read the backup header if the primary
-    /// header could not be read.
+    /// Read the MBR on a reader.
     ///
     /// # Examples
     /// Basic usage:


### PR DESCRIPTION
There is no backup MBR, and `read_from()` doesn't try to read one.  This appears to be a copy-paste error from `GPT::read_from()` in gptman.