### PR TITLE
workflows: update actions; remove monthly scheduled run

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,6 @@ name: Rust
 on:
   push:
     branches: [ main ]
-  schedule:
-    - cron: 0 0 1 * *
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
 
 env:
+  CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -27,43 +28,31 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Select Rust version
+      - name: Install toolchain
         shell: bash
         run: |
-          RUST_VER="${{ matrix.rust }}"
-          if [ "$RUST_VER" = msrv ]; then
-              RUST_VER=$(cargo metadata --format-version 1 --no-deps | \
+          ver="${{ matrix.rust }}"
+          if [ "$ver" = msrv ]; then
+              ver=$(cargo metadata --format-version 1 --no-deps | \
                   jq -r '.packages[0].rust_version')
-              echo "MSRV: $RUST_VER"
           fi
-          echo "RUST_VER=$RUST_VER" >> $GITHUB_ENV
+          rustup toolchain install "$ver" --profile minimal --no-self-update
+          rustup default "$ver"
+          echo "Installed:"
+          cargo --version
+          rustc --version --verbose
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_VER }}
-          default: true
-          override: true
-
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features
+        run: cargo test --workspace --all-features
 
       - name: rustfmt
         if: github.event_name == 'pull_request' && matrix.lint
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: clippy
         if: github.event_name == 'pull_request' && matrix.lint
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --tests --all-features -- -D warnings
+        run: cargo clippy --all --tests --all-features -- -D warnings


### PR DESCRIPTION
The older action versions are using deprecated APIs and throwing warnings.  All of the `actions-rs` actions are unmaintained, so switch to manually invoking commands.

GitHub disables scheduled workflows on repos that are inactive for two months, which is very likely to happen here.  As a result, the workflow would only run twice and then be disabled, taking all of our CI with it.  Drop the monthly scheduled run.