### PR TITLE
Update dependencies to allow building with latest Rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,10 +50,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Set serde-big-array to minimum version (0.4.1)
-        if: matrix.rust == 'msrv'
-        run: cargo update -p serde-big-array --precise 0.4.1
-
       - run: cargo test --workspace ${{ matrix.rust-args }}
 
       - run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
@@ -23,7 +24,7 @@ jobs:
           - msrv
         include:
           - os: ubuntu-latest
-            rust: stable
+            rust: msrv
             lint: 1
     runs-on: ${{ matrix.os }}
     steps:
@@ -36,9 +37,10 @@ jobs:
           ver="${{ matrix.rust }}"
           if [ "$ver" = msrv ]; then
               ver=$(cargo metadata --format-version 1 --no-deps | \
-                  jq -r '.packages[0].rust_version')
+                  jq -r 'first(.packages[] | select(.rust_version != null).rust_version)')
+              extra=(-c rustfmt -c clippy)
           fi
-          rustup toolchain install "$ver" --profile minimal --no-self-update
+          rustup toolchain install "$ver" --profile minimal --no-self-update "${extra[@]}"
           rustup default "$ver"
           echo "Installed:"
           cargo --version
@@ -46,13 +48,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: cargo test
-        run: cargo test --workspace --all-features
+      - run: cargo test --workspace --all-features
 
-      - name: rustfmt
+      - run: cargo fmt --all -- --check
         if: github.event_name == 'pull_request' && matrix.lint
-        run: cargo fmt --all -- --check
 
-      - name: clippy
+      - run: cargo clippy --all --tests --all-features -- -D warnings
         if: github.event_name == 'pull_request' && matrix.lint
-        run: cargo clippy --all --tests --all-features -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = ["src/**/*.rs", "tests/fixtures/*.img", "README.md", "LICENSE.Apache-2
 
 [dependencies]
 bitvec = "1.0.1"
-bincode = "1.0.1"
-serde = { version = "1.0.116", features = ["derive"] }
-serde-big-array = ">= 0.4.1, < 0.6"
-thiserror = "1.0.24"
+bincode = { version = "2.0.0-rc.3", features = ["serde"] }
+serde = { version = "1.0.210", features = ["derive"] }
+serde-big-array = "0.5.1"
+thiserror = "1.0.63"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "mbrman"
 version = "0.5.4"
 authors = ["Cecile Tonglet <cecile.tonglet@cecton.com>"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 description = "MBR Partition Management in Rust"
 repository = "https://github.com/rust-disk-partition-management/mbrman"
@@ -18,7 +18,7 @@ include = ["src/**/*.rs", "tests/fixtures/*.img", "README.md", "LICENSE.Apache-2
 
 [dependencies]
 bitvec = "1.0.1"
-bincode = { version = "2.0.0-rc.3", features = ["serde"] }
+bincode = { version = "2.0.1", features = ["serde"] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde-big-array = "0.5.1"
-thiserror = "1.0.63"
+thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/rust-disk-partition-management/mbrman"
 documentation = "https://docs.rs/mbrman"
 readme = "README.md"
 keywords = ["mbr", "partition", "table", "filesystem", "disk"]
-categories = []
+categories = ["filesystem"]
 include = ["src/**/*.rs", "tests/fixtures/*.img", "README.md", "LICENSE.Apache-2.0", "LICENSE.MIT"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,6 @@
 
 #![deny(missing_docs)]
 
-use bincode::{deserialize_from, serialize_into};
 use bitvec::prelude::*;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeTuple;
@@ -165,6 +164,9 @@ use serde_big_array::BigArray;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::iter::{once, repeat};
 use std::ops::{Index, IndexMut};
+use bincode::config::legacy;
+use bincode::error::{DecodeError, EncodeError};
+use bincode::serde::{decode_from_std_read, encode_into_std_write};
 use thiserror::Error;
 
 const DEFAULT_ALIGN: u32 = 2048;
@@ -196,7 +198,10 @@ pub enum Error {
     LBAExceedsMaximumCylinders,
     /// Deserialization errors.
     #[error("deserialization failed")]
-    Deserialize(#[from] bincode::Error),
+    Deserialize(#[from] DecodeError),
+    /// Serialization errors.
+    #[error("Serialization failed")]
+    Serialize(#[from] EncodeError),
     /// I/O errors.
     #[error("generic I/O error")]
     Io(#[from] std::io::Error),
@@ -377,7 +382,7 @@ impl MBR {
         S: Seek,
     {
         let disk_size = u32::try_from(seeker.seek(SeekFrom::End(0))? / u64::from(sector_size))
-            .unwrap_or(u32::max_value());
+            .unwrap_or(u32::MAX);
         let header = MBRHeader::new(disk_signature);
 
         Ok(MBR {
@@ -407,7 +412,7 @@ impl MBR {
         R: Read + Seek,
     {
         let disk_size = u32::try_from(reader.seek(SeekFrom::End(0))? / u64::from(sector_size))
-            .unwrap_or(u32::max_value());
+            .unwrap_or(u32::MAX);
         let header = MBRHeader::read_from(&mut reader)?;
 
         let mut logical_partitions = Vec::new();
@@ -451,7 +456,7 @@ impl MBR {
                 });
 
                 if next.starting_lba > 0 && relative_ebr_lba >= next.starting_lba {
-                    return Err(Error::InconsistentEBR);
+                    return Err(Error::from(Error::InconsistentEBR));
                 }
 
                 relative_ebr_lba = next.starting_lba;
@@ -576,11 +581,10 @@ impl MBR {
                 writer.seek(SeekFrom::Start(u64::from(
                     l.absolute_ebr_lba * self.sector_size,
                 )))?;
-                serialize_into(&mut writer, &BootstrapCode446(l.bootstrap_code))?;
-                serialize_into(&mut writer, &partition)?;
+                encode_into_std_write(&BootstrapCode446(l.bootstrap_code), &mut writer, legacy())?;
+                encode_into_std_write(&partition, &mut writer, legacy())?;
                 if let Some(next) = next {
-                    serialize_into(
-                        &mut writer,
+                    encode_into_std_write(
                         &MBRPartitionEntry {
                             boot: BOOT_INACTIVE,
                             first_chs: next.ebr_first_chs,
@@ -591,12 +595,14 @@ impl MBR {
                                 .saturating_sub(extended.starting_lba),
                             sectors: next.ebr_sectors.unwrap(),
                         },
+                        &mut writer,
+                        legacy()
                     )?;
                 } else {
-                    serialize_into(&mut writer, &MBRPartitionEntry::empty())?;
+                    encode_into_std_write(&MBRPartitionEntry::empty(), &mut writer, legacy())?;
                 }
                 writer.write_all(&[0; 16 * 2])?;
-                serialize_into(&mut writer, &BOOT_SIGNATURE)?;
+                encode_into_std_write(&BOOT_SIGNATURE, &mut writer, legacy())?;
             }
         }
 
@@ -1078,7 +1084,7 @@ impl MBRHeader {
         R: Read + Seek,
     {
         reader.seek(SeekFrom::Start(0))?;
-        let header: Self = deserialize_from(&mut reader)?;
+        let header: Self = decode_from_std_read(&mut reader, legacy())?;
         header.check()?;
         Ok(header)
     }
@@ -1105,7 +1111,7 @@ impl MBRHeader {
     {
         self.check()?;
         writer.seek(SeekFrom::Start(0))?;
-        serialize_into(&mut writer, &self)?;
+        encode_into_std_write(&self, &mut writer, legacy())?;
 
         Ok(())
     }
@@ -1123,14 +1129,14 @@ impl Index<usize> for MBRHeader {
     type Output = MBRPartitionEntry;
 
     fn index(&self, i: usize) -> &Self::Output {
-        assert!(i != 0, "invalid partition index: 0");
+        assert_ne!(i, 0, "invalid partition index: 0");
         self.get(i).expect("invalid partition")
     }
 }
 
 impl IndexMut<usize> for MBRHeader {
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        assert!(i != 0, "invalid partition index: 0");
+        assert_ne!(i, 0, "invalid partition index: 0");
         self.get_mut(i).expect("invalid partition")
     }
 }
@@ -1147,11 +1153,11 @@ struct EBRHeader {
 }
 
 impl EBRHeader {
-    fn read_from<R: ?Sized>(reader: &mut R) -> Result<EBRHeader>
+    fn read_from<R>(reader: &mut R) -> Result<EBRHeader>
     where
         R: Read,
     {
-        let header: Self = deserialize_from(reader)?;
+        let header: Self = decode_from_std_read(reader, legacy())?;
         header.check()?;
         Ok(header)
     }
@@ -1509,13 +1515,14 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Cursor;
+    use bincode::serde::{decode_from_slice, encode_into_slice};
 
     const DISK1: &str = "tests/fixtures/disk1.img";
     const DISK2: &str = "tests/fixtures/disk2.img";
 
     #[test]
     fn deserialize_maximum_chs_value() {
-        let chs: CHS = bincode::deserialize(&[0xff, 0xff, 0xff]).unwrap();
+        let chs: CHS = decode_from_slice(&[0xff, 0xff, 0xff], legacy()).unwrap().0;
         assert_eq!(
             chs,
             CHS {
@@ -1533,13 +1540,16 @@ mod tests {
             head: 255,
             sector: 63,
         };
-        let out = bincode::serialize(&chs).unwrap();
-        assert_eq!(out, &[0xff, 0xff, 0xff]);
+        let mut slice = [0; 3];
+        encode_into_slice(&chs, &mut slice, legacy()).unwrap();
+        for element in slice {
+            assert_eq!(element, 0xff);
+        }
     }
 
     #[test]
     fn serialize_and_deserialize_some_chs_value() {
-        let chs: CHS = bincode::deserialize(&[0xaa, 0xaa, 0xaa]).unwrap();
+        let chs: CHS = decode_from_slice(&[0xaa, 0xaa, 0xaa], legacy()).unwrap().0;
         assert_eq!(
             chs,
             CHS {
@@ -1548,8 +1558,11 @@ mod tests {
                 sector: 42,
             }
         );
-        let out = bincode::serialize(&chs).unwrap();
-        assert_eq!(out, &[0xaa, 0xaa, 0xaa]);
+        let mut slice = [0; 3];
+        encode_into_slice(&chs, &mut slice, legacy()).unwrap();
+        for element in slice {
+            assert_eq!(element, 0xaa);
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,7 @@ impl MBR {
                 });
 
                 if next.starting_lba > 0 && relative_ebr_lba >= next.starting_lba {
-                    return Err(Error::from(Error::InconsistentEBR));
+                    return Err(Error::InconsistentEBR);
                 }
 
                 relative_ebr_lba = next.starting_lba;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,7 +596,7 @@ impl MBR {
                             sectors: next.ebr_sectors.unwrap(),
                         },
                         &mut writer,
-                        legacy()
+                        legacy(),
                     )?;
                 } else {
                     encode_into_std_write(&MBRPartitionEntry::empty(), &mut writer, legacy())?;
@@ -1513,9 +1513,9 @@ impl Serialize for CHS {
 #[allow(clippy::cognitive_complexity)]
 mod tests {
     use super::*;
+    use bincode::serde::{decode_from_slice, encode_into_slice};
     use std::fs::File;
     use std::io::Cursor;
-    use bincode::serde::{decode_from_slice, encode_into_slice};
 
     const DISK1: &str = "tests/fixtures/disk1.img";
     const DISK2: &str = "tests/fixtures/disk2.img";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,9 @@
 
 #![deny(missing_docs)]
 
+use bincode::config::legacy;
+use bincode::error::{DecodeError, EncodeError};
+use bincode::serde::{decode_from_std_read, encode_into_std_write};
 use bitvec::prelude::*;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeTuple;
@@ -164,9 +167,6 @@ use serde_big_array::BigArray;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::iter::{once, repeat};
 use std::ops::{Index, IndexMut};
-use bincode::config::legacy;
-use bincode::error::{DecodeError, EncodeError};
-use bincode::serde::{decode_from_std_read, encode_into_std_write};
 use thiserror::Error;
 
 const DEFAULT_ALIGN: u32 = 2048;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,13 +486,13 @@ impl MBR {
 
     /// Updates the header to match the specifications of the seeker given in argument.
     /// `disk_size` will be updated after this operation.
-    pub fn update_from<S: ?Sized>(&mut self, seeker: &mut S) -> Result<()>
+    pub fn update_from<S>(&mut self, seeker: &mut S) -> Result<()>
     where
-        S: Seek,
+        S: Seek + ?Sized,
     {
         self.disk_size =
             u32::try_from(seeker.seek(SeekFrom::End(0))? / u64::from(self.sector_size))
-                .unwrap_or(u32::max_value());
+                .unwrap_or(u32::MAX);
         Ok(())
     }
 


### PR DESCRIPTION
Rust changing features broke proc, which broke any crates or dependencies using it. This PR simply updates to the latest version of each dependency to fix this issue.

Changes:
- Swapped to bincode 2.0.0, switching encode/decode methods to their 2.0.0 serde equivalent
- Fixed tests to use modern rust assert_eq and its variants
- swapped u32::max_value() to the modern u32::MAX suggested equivalent

I ran all tests, no errors.